### PR TITLE
add setEphemeral method 

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,10 +222,12 @@ Peer should look like this:
 
 Explicitly bind the dht node to a certain port/address.
 
-#### `node.turnNonEphemeral()`
+#### `node.joinDht()`
+
+This method is only useful for ephemeral nodes that we want to upgrade to non-ephemeral nodes.
 
 Dynamically and irreversibly begin allowing other nodes to add
-this node to the peer list.
+this node to their peer lists.
 
 #### `node.on('listening')`
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,11 @@ Peer should look like this:
 
 Explicitly bind the dht node to a certain port/address.
 
+#### `node.turnNonEphemeral()`
+
+Dynamically and irreversibly begin allowing other nodes to add
+this node to the peer list.
+
 #### `node.on('listening')`
 
 Emitted when the node starts listening on a udp port.

--- a/README.md
+++ b/README.md
@@ -222,12 +222,9 @@ Peer should look like this:
 
 Explicitly bind the dht node to a certain port/address.
 
-#### `node.joinDht()`
+#### `node.setEpehemeral(boolean)`
 
-This method is only useful for ephemeral nodes that we want to upgrade to non-ephemeral nodes.
-
-Dynamically and irreversibly begin allowing other nodes to add
-this node to their peer lists.
+Dynamically convert the node into ephemeral (leave the DHT) or non-ephemeral (join the DHT).
 
 #### `node.on('listening')`
 

--- a/index.js
+++ b/index.js
@@ -338,6 +338,12 @@ class DHT extends EventEmitter {
       qs._concurrency = self.inflightQueries === 1 ? self.concurrency : backgroundCon
     }
   }
+
+  turnNonEphemeral () {
+    if (this.ephemeral === false) return
+    this.ephemeral = false
+    this.io._updateId(this.id)
+  }
 }
 
 exports.QUERY = DHT.QUERY = IO.QUERY

--- a/index.js
+++ b/index.js
@@ -339,10 +339,11 @@ class DHT extends EventEmitter {
     }
   }
 
-  joinDht () {
+  joinDht (cb) {
     if (this.ephemeral === false) return
     this.ephemeral = false
-    this.io._updateId(this.id)
+    this._io._updateId(this.id)
+    this.bootstrap(cb)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -341,9 +341,15 @@ class DHT extends EventEmitter {
 
   joinDht (cb) {
     if (this.ephemeral === false) return
-    this.ephemeral = false
     this._io._updateId(this.id)
-    this.bootstrap(cb)
+    this.bootstrap((err) => {
+      if (err) {
+        if (cb) cb(err)
+        return
+      }
+      this.ephemeral = false
+      if (cb) cb()
+    })
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -100,6 +100,7 @@ class DHT extends EventEmitter {
   }
 
   _onping (message, peer) {
+    if (this.ephemeral === true) return
     if (message.value && !this.id.equals(message.value)) return
     this._io.response(message, peers.encode([ peer ]), null, peer)
   }
@@ -225,7 +226,6 @@ class DHT extends EventEmitter {
   _onnodeping (oldContacts, newContact) {
     // if bootstrapping, we've recently pinged all nodes
     if (!this.bootstrapped) return
-
     const reping = []
 
     for (var i = 0; i < oldContacts.length; i++) {
@@ -244,9 +244,13 @@ class DHT extends EventEmitter {
   }
 
   _check (node) {
+    console.log('CHECK!!!')
     const self = this
     this.ping(node, function (err) {
-      if (err) self._removeNode(node)
+      if (err) {
+        console.log('REMOVE NODE!')
+        self._removeNode(node)
+      }
     })
   }
 
@@ -341,6 +345,7 @@ class DHT extends EventEmitter {
   setEphemeral (ephemeral = false, cb) {
     if (ephemeral === true) {
       this._io._updateId(null)
+      this.ephemeral = true
       if (cb) process.nextTick(cb)
       return
     }

--- a/index.js
+++ b/index.js
@@ -339,7 +339,7 @@ class DHT extends EventEmitter {
     }
   }
 
-  turnNonEphemeral () {
+  joinDht () {
     if (this.ephemeral === false) return
     this.ephemeral = false
     this.io._updateId(this.id)

--- a/index.js
+++ b/index.js
@@ -271,7 +271,6 @@ class DHT extends EventEmitter {
   _pingSome () {
     var cnt = this.inflightQueries > 2 ? 1 : 3
     var oldest = this.nodes.oldest
-
     // tiny dht, ping the bootstrap again
     if (!oldest) return this.bootstrap()
 
@@ -339,8 +338,12 @@ class DHT extends EventEmitter {
     }
   }
 
-  joinDht (cb) {
-    if (this.ephemeral === false) return
+  setEphemeral (ephemeral = false, cb) {
+    if (ephemeral === true) {
+      this._io._updateId(null)
+      if (cb) process.nextTick(cb)
+      return
+    }
     this._io._updateId(this.id)
     this.bootstrap((err) => {
       if (err) {

--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ class DHT extends EventEmitter {
   _onping (message, peer) {
     if (this.ephemeral === true) return
     if (message.value && !this.id.equals(message.value)) return
-    this._io.response(message, peers.encode([ peer ]), null, peer)
+    this._io.response(message, peers.encode([peer]), null, peer)
   }
 
   _onholepunch (message, peer) {
@@ -113,7 +113,7 @@ class DHT extends EventEmitter {
       const to = decodePeer(value.to)
       if (!to || samePeer(to, peer)) return
       message.id = this._io.id
-      message.value = Holepunch.encode({ from: peers.encode([ peer ]) })
+      message.value = Holepunch.encode({ from: peers.encode([peer]) })
       this.emit('holepunch', peer, to)
       this._io.send(Message.encode(message), to)
       return
@@ -244,11 +244,9 @@ class DHT extends EventEmitter {
   }
 
   _check (node) {
-    console.log('CHECK!!!')
     const self = this
     this.ping(node, function (err) {
       if (err) {
-        console.log('REMOVE NODE!')
         self._removeNode(node)
       }
     })

--- a/index.js
+++ b/index.js
@@ -100,7 +100,6 @@ class DHT extends EventEmitter {
   }
 
   _onping (message, peer) {
-    if (this.ephemeral === true) return
     if (message.value && !this.id.equals(message.value)) return
     this._io.response(message, peers.encode([peer]), null, peer)
   }

--- a/lib/io.js
+++ b/lib/io.js
@@ -24,7 +24,7 @@ class IO {
     this._rid = (Math.random() * 65536) | 0
     this._requests = new Array(65536)
     this._pending = []
-    this._secrets = [ randomBytes(32), randomBytes(32) ]
+    this._secrets = [randomBytes(32), randomBytes(32)]
     this._ticking = false
     this._tickInterval = setInterval(this._ontick.bind(this), 250)
     this._rotateInterval = setInterval(this._onrotate.bind(this), 300000)
@@ -78,7 +78,7 @@ class IO {
       rid,
       command: '_holepunch',
       value: Holepunch.encode({
-        to: peers.encode([ req.peer ])
+        to: peers.encode([req.peer])
       })
     }
 
@@ -115,6 +115,7 @@ class IO {
         break
     }
   }
+
   _finish (rid, err, val, peer) {
     const req = this._requests[rid]
     if (!req) return
@@ -281,6 +282,7 @@ class IO {
       value
     }, peer, callback)
   }
+
   _updateId (id) {
     this.id = id
   }

--- a/lib/io.js
+++ b/lib/io.js
@@ -28,7 +28,7 @@ class IO {
     this._ticking = false
     this._tickInterval = setInterval(this._ontick.bind(this), 250)
     this._rotateInterval = setInterval(this._onrotate.bind(this), 300000)
-    this._updatingMeta = null
+
     socket.on('message', this._onmessage.bind(this))
   }
 
@@ -281,7 +281,7 @@ class IO {
       value
     }, peer, callback)
   }
-  updateId (id) {
+  _updateId (id) {
     this.id = id
   }
 }

--- a/lib/io.js
+++ b/lib/io.js
@@ -219,6 +219,19 @@ class IO {
   }
 
   response (request, value, closerNodes, peer) {
+    if (this._ctx.ephemeral) {
+      const privateCommand = request.command.slice(0, 1) === '_'
+      if (privateCommand === false) {
+        // if a node was non-ephemeral and then was
+        // set to ephemeral, other DHT nodes will
+        // still have a reference to the node. Therefore
+        // if the node is ephemeral and the request
+        // is not a DHT internals command ignore the
+        // request to make other nodes remove it from
+        // their list.
+        return
+      }
+    }
     const message = {
       type: TYPE.RESPONSE,
       rid: request.rid,
@@ -227,7 +240,6 @@ class IO {
       roundtripToken: this._token(peer, 0),
       value
     }
-
     this.send(Message.encode(message), peer)
   }
 

--- a/lib/io.js
+++ b/lib/io.js
@@ -220,7 +220,7 @@ class IO {
 
   response (request, value, closerNodes, peer) {
     if (this._ctx.ephemeral) {
-      const privateCommand = request.command.slice(0, 1) === '_'
+      const privateCommand = request.command.charCodeAt(0) === 95 // '_'
       if (privateCommand === false) {
         // if a node was non-ephemeral and then was
         // set to ephemeral, other DHT nodes will

--- a/lib/io.js
+++ b/lib/io.js
@@ -28,7 +28,7 @@ class IO {
     this._ticking = false
     this._tickInterval = setInterval(this._ontick.bind(this), 250)
     this._rotateInterval = setInterval(this._onrotate.bind(this), 300000)
-
+    this._updatingMeta = null
     socket.on('message', this._onmessage.bind(this))
   }
 
@@ -115,7 +115,6 @@ class IO {
         break
     }
   }
-
   _finish (rid, err, val, peer) {
     const req = this._requests[rid]
     if (!req) return
@@ -281,6 +280,9 @@ class IO {
       command,
       value
     }, peer, callback)
+  }
+  updateId (id) {
+    this.id = id
   }
 }
 

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -11,9 +11,9 @@ var varint = encodings.varint
 var skip = encodings.skip
 
 exports.TYPE = {
-  "QUERY": 1,
-  "UPDATE": 2,
-  "RESPONSE": 3
+  QUERY: 1,
+  UPDATE: 2,
+  RESPONSE: 3
 }
 
 var Holepunch = exports.Holepunch = {

--- a/lib/query-stream.js
+++ b/lib/query-stream.js
@@ -96,6 +96,11 @@ class QueryStream extends Readable {
       return
     }
 
+    if (message.id === null) {
+      this._readMaybe()
+      return
+    }
+
     const value = this._outputEncoding
       ? this._decodeOutput(message.value)
       : message.value

--- a/lib/query-stream.js
+++ b/lib/query-stream.js
@@ -48,7 +48,6 @@ class QueryStream extends Readable {
 
   _onresponse (err, message, peer, request, to, type) {
     this.inflight--
-
     if (err && to && to.id) {
       // Request, including retries, failed completely
       // Remove the "to" node.

--- a/test.js
+++ b/test.js
@@ -278,7 +278,7 @@ tape('setEphemeral(true)', function (t) {
                   node.destroy()
                   t.end()
                 })
-              }, 5000)
+              })
             }, 5000)
           })
         })

--- a/test.js
+++ b/test.js
@@ -250,6 +250,8 @@ tape('setEphemeral(true)', function (t) {
   bootstrap(function (port, node) {
     const a = dht({ bootstrap: port, ephemeral: false })
     const b = dht({ bootstrap: port })
+    a.name = 'a'
+    b.name = 'b'
     a.command('hello', {
       query (data, callback) {
         callback(null, Buffer.from('world'))
@@ -265,10 +267,9 @@ tape('setEphemeral(true)', function (t) {
           t.is(Buffer.compare(result[0].node.id, a.id), 0)
           a.setEphemeral(true, (err) => {
             t.error(err)
-            // wait a tick interval
-            setTimeout(() => {
+            setTimeout(() => { // wait for a tick interval
               b._pingSome()
-              b.bootstrap(() => {
+              b.once('remove-node', () => {
                 b.query('hello', key, (err, result) => {
                   t.error(err)
                   t.is(result.length, 0)
@@ -277,7 +278,7 @@ tape('setEphemeral(true)', function (t) {
                   node.destroy()
                   t.end()
                 })
-              })
+              }, 5000)
             }, 5000)
           })
         })

--- a/test.js
+++ b/test.js
@@ -212,6 +212,40 @@ tape('timeouts', function (t) {
   })
 })
 
+tape('joinDht', function (t) {
+  bootstrap(function (port, node) {
+    const a = dht({ bootstrap: port, ephemeral: true })
+    const b = dht({ bootstrap: port })
+    a.command('hello', {
+      query (data, callback) {
+        callback(null, Buffer.from('world'))
+      }
+    })
+
+    a.ready(function () {
+      b.ready(function () {
+        const key = blake2b(Buffer.from('hello'))
+        b.query('hello', key, (err, result) => {
+          t.error(err)
+          t.is(result.length, 0)
+          a.joinDht((err) => {
+            t.error(err)
+            b.query('hello', key, (err, result) => {
+              t.error(err)
+              t.is(result.length, 1)
+              t.is(Buffer.compare(result[0].node.id, a.id), 0)
+              a.destroy()
+              b.destroy()
+              node.destroy()
+              t.end()
+            })
+          })
+        })
+      })
+    })
+  })
+})
+
 function bootstrap (done) {
   const node = dht({
     ephemeral: true

--- a/test.js
+++ b/test.js
@@ -266,19 +266,19 @@ tape('setEphemeral(true)', function (t) {
           t.is(Buffer.compare(result[0].node.id, a.id), 0)
           a.setEphemeral(true, (err) => {
             t.error(err)
-            setTimeout(() => { // wait for a tick interval
-              b._pingSome()
-              b.once('remove-node', () => {
-                b.query('hello', key, (err, result) => {
-                  t.error(err)
-                  t.is(result.length, 0)
-                  a.destroy()
-                  b.destroy()
-                  node.destroy()
-                  t.end()
-                })
+            b.query('hello', key, (err, result) => {
+              t.ok(err)
+            })
+            b.once('remove-node', () => {
+              b.query('hello', key, (err, result) => {
+                t.error(err)
+                t.is(result.length, 0)
+                a.destroy()
+                b.destroy()
+                node.destroy()
+                t.end()
               })
-            }, 5000)
+            })
           })
         })
       })

--- a/test.js
+++ b/test.js
@@ -212,7 +212,7 @@ tape('timeouts', function (t) {
   })
 })
 
-tape('joinDht', function (t) {
+tape('setEphemeral(false)', function (t) {
   bootstrap(function (port, node) {
     const a = dht({ bootstrap: port, ephemeral: true })
     const b = dht({ bootstrap: port })
@@ -228,7 +228,7 @@ tape('joinDht', function (t) {
         b.query('hello', key, (err, result) => {
           t.error(err)
           t.is(result.length, 0)
-          a.joinDht((err) => {
+          a.setEphemeral(false, (err) => {
             t.error(err)
             b.query('hello', key, (err, result) => {
               t.error(err)
@@ -239,6 +239,46 @@ tape('joinDht', function (t) {
               node.destroy()
               t.end()
             })
+          })
+        })
+      })
+    })
+  })
+})
+
+tape('setEphemeral(true)', function (t) {
+  bootstrap(function (port, node) {
+    const a = dht({ bootstrap: port, ephemeral: false })
+    const b = dht({ bootstrap: port })
+    a.command('hello', {
+      query (data, callback) {
+        callback(null, Buffer.from('world'))
+      }
+    })
+
+    a.ready(function () {
+      b.ready(function () {
+        const key = blake2b(Buffer.from('hello'))
+        b.query('hello', key, (err, result) => {
+          t.error(err)
+          t.is(result.length, 1)
+          t.is(Buffer.compare(result[0].node.id, a.id), 0)
+          a.setEphemeral(true, (err) => {
+            t.error(err)
+            // wait a tick interval
+            setTimeout(() => {
+              b._pingSome()
+              b.bootstrap(() => {
+                b.query('hello', key, (err, result) => {
+                  t.error(err)
+                  t.is(result.length, 0)
+                  a.destroy()
+                  b.destroy()
+                  node.destroy()
+                  t.end()
+                })
+              })
+            }, 5000)
           })
         })
       })

--- a/test.js
+++ b/test.js
@@ -250,8 +250,7 @@ tape('setEphemeral(true)', function (t) {
   bootstrap(function (port, node) {
     const a = dht({ bootstrap: port, ephemeral: false })
     const b = dht({ bootstrap: port })
-    a.name = 'a'
-    b.name = 'b'
+
     a.command('hello', {
       query (data, callback) {
         callback(null, Buffer.from('world'))


### PR DESCRIPTION
This method will be useful for dynamically converting a node to non-ephemeral after reacting to heuristics to determine an initially ephemeral yet long running node.

I explored the idea of setting the concurrency to 0 and then waiting for the IO inflight queue to reduce to 0 before updating the IO id and restoring concurrency but after thinking through it more this seems unnecessary. As far as I understand, there's no harm in immediately publishing the peer ID.

It also seems going the other way (making a node ephemeral) is harder because.. that will mean assigning a new id so requests are ignored.. it seems like there could be unforeseen implications in doing that - hence the one way street. 