### PR TITLE
graceful destroy

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,6 +171,7 @@ class DHT extends EventEmitter {
   }
 
   destroy () {
+    if (this.destroyed) return
     this.destroyed = true
     this._io.destroy()
     clearInterval(this._tickInterval)

--- a/lib/io.js
+++ b/lib/io.js
@@ -201,6 +201,7 @@ class IO {
   }
 
   send (buffer, peer) {
+    if (this._ctx.destroyed) return
     this.socket.send(buffer, 0, buffer.length, peer.port, peer.host)
   }
 


### PR DESCRIPTION
this avoids the error `ERR_SOCKET_DGRAM_NOT_RUNNING` in cases where `destroy` is called multiple times or in race conditions where `send` is triggered after destroy is called