### PR TITLE
increase retry for greater scale

### DIFF
--- a/lib/io.js
+++ b/lib/io.js
@@ -26,7 +26,7 @@ class IO {
     this._pending = []
     this._secrets = [ randomBytes(32), randomBytes(32) ]
     this._ticking = false
-    this._tickInterval = setInterval(this._ontick.bind(this), 250)
+    this._tickInterval = setInterval(this._ontick.bind(this), 750)
     this._rotateInterval = setInterval(this._onrotate.bind(this), 300000)
 
     socket.on('message', this._onmessage.bind(this))


### PR DESCRIPTION
with scale tests (250 peers, 1000 round trips) we've found that lookup failures are likely - increasing tick interval to 750ms makes eliminates failures at this scale